### PR TITLE
scikit-learn is required by imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 fastai
 opencv-python
 openslide-python
+scikit-learn


### PR DESCRIPTION
scikit-learn is required by imports but a version to satisfy the imports wasn't installed with fastai 1.0.60